### PR TITLE
fix typo

### DIFF
--- a/kube/shell/init.sh
+++ b/kube/shell/init.sh
@@ -76,8 +76,7 @@ cp ../conf/kubelet.service /etc/systemd/system/
 [ -d /etc/systemd/system/kubelet.service.d ] || mkdir /etc/systemd/system/kubelet.service.d
 cp ../conf/10-kubeadm.conf /etc/systemd/system/kubelet.service.d/
 
-cgroupDriver=$(docker info|grep "Cgroup Driver")
-driver=${cgroupDriver##*: }
+driver=$(docker info -f "{{.CgroupDriver}}")
 echo "driver is ${driver}"
 
 [ -d /var/lib/kubelet ] || mkdir -p /var/lib/kubelet/

--- a/kube/shell/init.sh
+++ b/kube/shell/init.sh
@@ -76,7 +76,7 @@ cp ../conf/kubelet.service /etc/systemd/system/
 [ -d /etc/systemd/system/kubelet.service.d ] || mkdir /etc/systemd/system/kubelet.service.d
 cp ../conf/10-kubeadm.conf /etc/systemd/system/kubelet.service.d/
 
-cgroupDriver=$(docker info|grep Cg)
+cgroupDriver=$(docker info|grep "Cgroup Driver")
 driver=${cgroupDriver##*: }
 echo "driver is ${driver}"
 


### PR DESCRIPTION
```bash
root@k8s-cluster01:~# cgroupDriver=$(docker info|grep Cg)
WARNING: No blkio weight support
WARNING: No blkio weight_device support
root@k8s-cluster01:~# driver=${cgroupDriver##*: }
root@k8s-cluster01:~# echo "driver is ${driver}"
driver is 1
```